### PR TITLE
Client error report summary

### DIFF
--- a/client_error_trace.admin.inc
+++ b/client_error_trace.admin.inc
@@ -5,7 +5,6 @@
  */
 
 use Drupal\client_error_trace\ClientErrorPluginManager;
-use Drupal\client_error_trace\Plugin\client_error\ClientErrorInterface;
 use GuzzleHttp\Url;
 
 /**
@@ -14,6 +13,56 @@ use GuzzleHttp\Url;
 function client_error_trace_form($form, &$form_state) {
   $form = array();
 
+  _client_error_trace_report($form, $form_state);
+
+  $form['url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('The public URL to trace'),
+    '#description' => t('Enter the URL to test as used by the public.'),
+    '#required' => TRUE,
+    '#default_value' => isset($form_state['values']['url']) ? $form_state['values']['url'] : '',
+  );
+
+  _client_error_trace_plugins($form);
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Trace errors'),
+  );
+
+  return $form;
+}
+
+/**
+ * Helper function to add a list of available validations to a form.
+ *
+ * @param array &$form
+ *   The form to add a 'plugins' item to.
+ */
+function _client_error_trace_plugins(array &$form) {
+  $manager = ClientErrorPluginManager::create();
+  $options = array();
+  foreach ($manager->getDefinitions() as $plugin) {
+    $options[$plugin['id']] = $plugin['description'];
+  }
+
+  $form['plugins'] = array(
+    '#type' => 'checkboxes',
+    '#options' => $options,
+    '#title' => t('Validations'),
+    '#default_value' => array_keys($options),
+  );
+}
+
+/**
+ * Helper function to add a client error report to a form.
+ *
+ * @param array &$form
+ *   The form to modify.
+ * @param array &$form_state
+ *   The current state of the form.
+ */
+function _client_error_trace_report(array &$form, array &$form_state) {
   if (isset($form_state['report'])) {
     $form['report'] = array(
       '#markup' => $form_state['report'],
@@ -32,56 +81,23 @@ function client_error_trace_form($form, &$form_state) {
       ),
     );
   }
-
-  $form['url'] = array(
-    '#type' => 'textfield',
-    '#title' => t('The public URL to trace'),
-    '#description' => t('Enter the URL to test as used by the public.'),
-    '#required' => TRUE,
-    '#default_value' => isset($form_state['values']['url']) ? $form_state['values']['url'] : '',
-  );
-
-  $manager = ClientErrorPluginManager::create();
-  $options = array();
-  foreach ($manager->getDefinitions() as $plugin) {
-    $options[$plugin['id']] = $plugin['description'];
-  }
-
-  $form['plugins'] = array(
-    '#type' => 'checkboxes',
-    '#options' => $options,
-    '#title' => t('Validations'),
-    '#default_value' => array_keys($options),
-  );
-
-  $form['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Trace errors'),
-  );
-
-  return $form;
 }
 
 /**
  * Form callback to run tests against a URL.
+ *
+ * @param array &$form
+ *   The form being submitted.
+ * @param array &$form_state
+ *   The current state of the form.
+ *
+ * @throws \Exception
+ *   Thrown if a client_error plugin could not execute.
  */
-function client_error_trace_form_submit(&$form, &$form_state) {
-  $url = Url::fromString($form_state['values']['url']);
+function client_error_trace_form_submit(array &$form, array &$form_state) {
   $manager = ClientErrorPluginManager::create();
-  $results = array();
-  foreach ($form_state['values']['plugins'] as $plugin) {
-    /** @var ClientErrorInterface $instance */
-    $instance = $manager->createInstance($plugin);
-    $report = $instance->execute($url);
-
-    $results[] = theme('client_error_trace_item', array(
-      'result' => $report->result(),
-      'description' => check_plain($manager->getDefinition($plugin)['description']),
-      'message' => $report->resultMessage(),
-      'suggestions' => $report->suggestions(),
-    ));
-
-  }
+  $url = Url::fromString($form_state['values']['url']);
+  $results = $manager->execute($url, $form_state['values']['plugins']);
 
   $form_state['report'] = theme('client_error_trace_report', array('url' => $url, 'results' => $results));
 

--- a/client_error_trace.admin.inc
+++ b/client_error_trace.admin.inc
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @file
+ * Administration page callbacks.
+ */
+
+use Drupal\client_error_trace\ClientErrorPluginManager;
+use Drupal\client_error_trace\Plugin\client_error\ClientErrorInterface;
+use GuzzleHttp\Url;
+
+/**
+ * Form callback to run tests against a URL.
+ */
+function client_error_trace_form($form, &$form_state) {
+  $form = array(
+    'url' => array(
+      '#type' => 'textfield',
+      '#title' => t('The public URL to trace.'),
+      '#description' => t('Enter the URL to test as used by the public.'),
+      '#required' => TRUE,
+    ),
+  );
+
+  $manager = ClientErrorPluginManager::create();
+  $options = array();
+  foreach ($manager->getDefinitions() as $plugin) {
+    $options[$plugin['id']] = $plugin['description'];
+  }
+
+  $form['plugins'] = array(
+    '#type' => 'checkboxes',
+    '#options' => $options,
+    '#title' => t('Validations'),
+    '#default_value' => array_keys($options),
+  );
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Trace errors'),
+  );
+
+  return $form;
+}
+
+/**
+ * Form callback to run tests against a URL.
+ */
+function client_error_trace_form_submit(&$form, &$form_state) {
+  $url = Url::fromString($form_state['values']['url']);
+  $manager = ClientErrorPluginManager::create();
+  foreach ($form_state['values']['plugins'] as $plugin) {
+    /** @var ClientErrorInterface $instance */
+    $instance = $manager->createInstance($plugin);
+    $report = $instance->execute($url);
+    drupal_set_message($report->resultMessage());
+    if ($report->hasSuggestions()) {
+      drupal_set_message(implode(', ', $report->suggestions()));
+    }
+  }
+}

--- a/client_error_trace.admin.inc
+++ b/client_error_trace.admin.inc
@@ -12,13 +12,33 @@ use GuzzleHttp\Url;
  * Form callback to run tests against a URL.
  */
 function client_error_trace_form($form, &$form_state) {
-  $form = array(
-    'url' => array(
-      '#type' => 'textfield',
-      '#title' => t('The public URL to trace.'),
-      '#description' => t('Enter the URL to test as used by the public.'),
-      '#required' => TRUE,
-    ),
+  $form = array();
+
+  if (isset($form_state['report'])) {
+    $form['report'] = array(
+      '#markup' => $form_state['report'],
+    );
+
+    $form['html_report'] = array(
+      '#title' => t('Report in HTML format'),
+      '#type' => 'fieldset',
+      '#collapsed' => TRUE,
+      '#collapsible' => TRUE,
+      'html' => array(
+        '#type' => 'textarea',
+        '#description' => t('Use this for easy pasting into a support ticket.'),
+        '#value' => $form_state['report'],
+        '#attributes' => array('readonly' => 'readonly'),
+      ),
+    );
+  }
+
+  $form['url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('The public URL to trace'),
+    '#description' => t('Enter the URL to test as used by the public.'),
+    '#required' => TRUE,
+    '#default_value' => isset($form_state['values']['url']) ? $form_state['values']['url'] : '',
   );
 
   $manager = ClientErrorPluginManager::create();
@@ -48,13 +68,22 @@ function client_error_trace_form($form, &$form_state) {
 function client_error_trace_form_submit(&$form, &$form_state) {
   $url = Url::fromString($form_state['values']['url']);
   $manager = ClientErrorPluginManager::create();
+  $results = array();
   foreach ($form_state['values']['plugins'] as $plugin) {
     /** @var ClientErrorInterface $instance */
     $instance = $manager->createInstance($plugin);
     $report = $instance->execute($url);
-    drupal_set_message($report->resultMessage());
-    if ($report->hasSuggestions()) {
-      drupal_set_message(implode(', ', $report->suggestions()));
-    }
+
+    $results[] = theme('client_error_trace_item', array(
+      'result' => $report->result(),
+      'description' => check_plain($manager->getDefinition($plugin)['description']),
+      'message' => $report->resultMessage(),
+      'suggestions' => $report->suggestions(),
+    ));
+
   }
+
+  $form_state['report'] = theme('client_error_trace_report', array('url' => $url, 'results' => $results));
+
+  $form_state['rebuild'] = TRUE;
 }

--- a/client_error_trace.module
+++ b/client_error_trace.module
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @file
+ * Hook implementations for client_error_trace.
+ */
 
 /**
  * Implements hook_menu().
@@ -30,7 +34,12 @@ function client_error_trace_theme($existing, $type, $theme, $path) {
       'template' => 'client_error_trace_report',
     ),
     'client_error_trace_item' => array(
-      'variables' => array('result' => NULL, 'description' => NULL, 'message' => NULL, 'suggestions' => NULL),
+      'variables' => array(
+        'result' => NULL,
+        'description' => NULL,
+        'message' => NULL,
+        'suggestions' => NULL,
+      ),
       'path' => drupal_get_path('module', 'client_error_trace') . '/template',
       'template' => 'client_error_trace_item',
     ),

--- a/client_error_trace.module
+++ b/client_error_trace.module
@@ -1,9 +1,5 @@
 <?php
 
-use Drupal\client_error_trace\ClientErrorPluginManager;
-use Drupal\client_error_trace\Plugin\client_error\ClientErrorInterface;
-use GuzzleHttp\Url;
-
 /**
  * Implements hook_menu().
  */
@@ -16,59 +12,9 @@ function client_error_trace_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('client_error_trace_form'),
     'access arguments' => array('administer site'),
+    'file' => 'client_error_trace.admin.inc',
     'type' => MENU_NORMAL_ITEM,
   );
 
   return $items;
-}
-
-/**
- * Form callback to run tests against a URL.
- */
-function client_error_trace_form($form, &$form_state) {
-  $form = array(
-    'url' => array(
-      '#type' => 'textfield',
-      '#title' => t('The public URL to trace.'),
-      '#description' => t('Enter the URL to test as used by the public.'),
-      '#required' => TRUE,
-    ),
-  );
-
-  $manager = ClientErrorPluginManager::create();
-  $options = array();
-  foreach ($manager->getDefinitions() as $plugin) {
-    $options[$plugin['id']] = $plugin['description'];
-  }
-
-  $form['plugins'] = array(
-    '#type' => 'checkboxes',
-    '#options' => $options,
-    '#title' => t('Validations'),
-    '#default_value' => array_keys($options),
-  );
-
-  $form['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Trace errors'),
-  );
-
-  return $form;
-}
-
-/**
- * Form callback to run tests against a URL.
- */
-function client_error_trace_form_submit(&$form, &$form_state) {
-  $url = Url::fromString($form_state['values']['url']);
-  $manager = ClientErrorPluginManager::create();
-  foreach ($form_state['values']['plugins'] as $plugin) {
-    /** @var ClientErrorInterface $instance */
-    $instance = $manager->createInstance($plugin);
-    $report = $instance->execute($url);
-    drupal_set_message($report->resultMessage());
-    if ($report->hasSuggestions()) {
-      drupal_set_message(implode(', ', $report->suggestions()));
-    }
-  }
 }

--- a/client_error_trace.module
+++ b/client_error_trace.module
@@ -18,3 +18,21 @@ function client_error_trace_menu() {
 
   return $items;
 }
+
+/**
+ * Implements hook_theme().
+ */
+function client_error_trace_theme($existing, $type, $theme, $path) {
+  return array(
+    'client_error_trace_report' => array(
+      'variables' => array('url' => NULL, 'results' => NULL),
+      'path' => drupal_get_path('module', 'client_error_trace') . '/template',
+      'template' => 'client_error_trace_report',
+    ),
+    'client_error_trace_item' => array(
+      'variables' => array('result' => NULL, 'description' => NULL, 'message' => NULL, 'suggestions' => NULL),
+      'path' => drupal_get_path('module', 'client_error_trace') . '/template',
+      'template' => 'client_error_trace_item',
+    ),
+  );
+}

--- a/src/ClientErrorPluginManager.php
+++ b/src/ClientErrorPluginManager.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * @file
+ * Manager to load ClientError plugins.
+ */
 
 namespace Drupal\client_error_trace;
 
+use Drupal\client_error_trace\Plugin\client_error\ClientErrorInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\plug\Util\Module;
+use GuzzleHttp\Url;
 
 /**
  * Manager to load ClientError plugins.
@@ -12,24 +18,63 @@ use Drupal\plug\Util\Module;
  * annotations, and load instances of them.
  *
  * @class ClientErrorPluginManager
+ *
  * @package Drupal\client_error_trace
  */
 class ClientErrorPluginManager extends DefaultPluginManager {
 
   /**
    * Helper function to create a new instance loaded with all module plugins.
+   *
    * @return static
+   *   A new instance of this manager.
    */
   public static function create() {
     return new static(Module::getNamespaces());
   }
 
   /**
+   * Construct a new ClientErrorPluginManager.
+   *
    * @param \Traversable $namespaces
+   *   An array of namespaces to search for client_error plugins in.
    */
   public function __construct(\Traversable $namespaces) {
     parent::__construct('Plugin/client_error', $namespaces, 'Drupal\client_error_trace\Plugin\client_error\ClientErrorInterface', '\Drupal\client_error_trace\Annotation\ClientError');
     // TODO: $this->setCacheBackend($cache)
     $this->alterInfo('client_error_plugin');
   }
+
+  /**
+   * Helper method to execute ClientError plugins against a URL.
+   *
+   * @param Url $url
+   *   The URL to execute plugins against.
+   * @param array $plugins
+   *   An array of plugin identifiers.
+   *
+   * @throws \Exception
+   *   Thrown if a plugin could not be instantiated.
+   *
+   * @return array
+   *   An array of report results as HTML strings.
+   */
+  public function execute(Url $url, array $plugins) {
+    $results = array();
+    foreach ($plugins as $plugin) {
+      /** @var ClientErrorInterface $instance */
+      $instance = $this->createInstance($plugin);
+      $report = $instance->execute($url);
+
+      $results[] = theme('client_error_trace_item', array(
+        'result' => $report->result(),
+        'description' => check_plain($this->getDefinition($plugin)['description']),
+        'message' => $report->resultMessage(),
+        'suggestions' => $report->suggestions(),
+      ));
+    }
+
+    return $results;
+  }
+
 }

--- a/src/Plugin/client_error/AccessContentReport.php
+++ b/src/Plugin/client_error/AccessContentReport.php
@@ -38,7 +38,7 @@ class AccessContentReport extends ReportBase {
 
     switch ($this->result) {
       case static::FAILED:
-        $suggestions[] = $this->t('Give anonymous users <a href="@permissions">permission to access content</a>.', array('@permissions' => url('admin/people/permissions')));
+        $suggestions[] = $this->t('Give anonymous users <a href="@permissions">permission to view published content</a>.', array('@permissions' => url('admin/people/permissions')));
         break;
 
       case static::SKIPPED:

--- a/src/Plugin/client_error/ReportInterface.php
+++ b/src/Plugin/client_error/ReportInterface.php
@@ -42,6 +42,7 @@ interface ReportInterface {
    * Return the message associated with this report.
    *
    * @return string
+   *   The result message as a translated string.
    */
   public function resultMessage();
 

--- a/template/client_error_trace_item.tpl.php
+++ b/template/client_error_trace_item.tpl.php
@@ -1,0 +1,39 @@
+<?php
+
+use Drupal\client_error_trace\Plugin\client_error\ReportInterface;
+
+/**
+ * Template for a single client error report item.
+ *
+ * @var int $result
+ *   The result of the report, as a constant from ReportInterface.
+ * @var string $description
+ *   The description of the test that was run.
+ * @var $message
+ *   The result message of the test.
+ * @var $suggestions
+ *   An array of suggestions with possible fixes for any failures.
+ */
+?>
+<h2>
+  <?php if ($result == ReportInterface::SUCCESS): ?>
+    <strong><?php print t('Passed'); ?>:</strong>
+  <?php elseif ($result == ReportInterface::SKIPPED): ?>
+    <strong><?php print t('Skipped'); ?>:</strong>
+  <?php else: ?>
+    <strong><?php print t('Failed'); ?>:</strong>
+  <?php endif; ?>
+
+  <?php print $description; ?>
+</h2>
+
+<p><?php print $message; ?></p>
+
+<?php if (!empty($suggestions)): ?>
+  <h3><?php print t('Fix suggestions'); ?></h3>
+  <ul>
+  <?php foreach ($suggestions as $suggestion): ?>
+    <li><?php print $suggestion; ?></li>
+  <?php endforeach; ?>
+  </ul>
+<?php endif; ?>

--- a/template/client_error_trace_report.tpl.php
+++ b/template/client_error_trace_report.tpl.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Template for a client error report.
+ *
+ * @var string $url
+ *   The URL the report was executed against.
+ * @var array $results
+ *   An array of strings with the result for each test.
+ */
+?>
+<h1><?php print t('Client error report for <a href="@url">@url</a>', array('@url' => $url)); ?></h1>
+
+<?php foreach ($results as $result): ?>
+<?php print $result; ?>
+<?php endforeach; ?>


### PR DESCRIPTION
This PR iterates over the results of an error check, adding a report with suggestions along with an easy copy / paste report for bug reports.

It could probably use some cleanup in the visual presentation, but this at least gives something that works.
![client error trace site-install 2015-03-02 14-12-22](https://cloud.githubusercontent.com/assets/255023/6448184/20d30024-c0e6-11e4-9a3c-95de976b52c8.jpg)
